### PR TITLE
Add simple companion-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .*sw[po]
+autorizo
+companion-api/companion-api

--- a/api/basic.go
+++ b/api/basic.go
@@ -24,7 +24,7 @@ func (api *API) basicAuthenticate(request *restful.Request, response *restful.Re
 	defer func() {
 		if err := recover(); err != nil {
 			// unhandled error
-			writeError(err.(error), response)
+			WriteError(err.(error), response)
 		}
 	}()
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -8,7 +8,8 @@ import (
 	"github.com/emicklei/go-restful"
 )
 
-func writeError(err error, response *restful.Response) {
+// Write error in good http format with error stack in it
+func WriteError(err error, response *restful.Response) {
 	response.AddHeader("Content-Type", "text/plain")
 
 	if rfErr, ok := err.(restful.ServiceError); ok {

--- a/api/keystone.go
+++ b/api/keystone.go
@@ -80,13 +80,13 @@ func (api *API) keystoneAuthenticate(request *restful.Request, response *restful
 	defer func() {
 		if err := recover(); err != nil {
 			// unhandled error
-			writeError(err.(error), response)
+			WriteError(err.(error), response)
 		}
 	}()
 
 	authReq := KeystoneAuthReq{}
 	if err := request.ReadEntity(&authReq); err != nil {
-		writeError(err, response)
+		WriteError(err, response)
 		return
 	}
 	if authReq.Auth == nil {

--- a/api/simple.go
+++ b/api/simple.go
@@ -37,13 +37,13 @@ func (api *API) simpleAuthenticate(request *restful.Request, response *restful.R
 	defer func() {
 		if err := recover(); err != nil {
 			// unhandled error
-			writeError(err.(error), response)
+			WriteError(err.(error), response)
 		}
 	}()
 
 	authReq := AuthReq{}
 	if err := request.ReadEntity(&authReq); err != nil {
-		writeError(err, response)
+		WriteError(err, response)
 		return
 	}
 

--- a/auth/etcd/etcd.go
+++ b/auth/etcd/etcd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mcluseau/autorizo/auth"
 )
 
+// New Authenticator with etcd backend
 func New(prefix string, endpoints []string) api.Authenticator {
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints: endpoints,
@@ -49,12 +50,14 @@ type etcdAuth struct {
 
 var _ api.Authenticator = &etcdAuth{}
 
+// User describe an user stored in etcd
 type User struct {
 	PasswordHash string `json:"password_hash"`
 	auth.ExtraClaims
 }
 
 func (a *etcdAuth) Authenticate(user, password string, expiresAt time.Time) (claims jwt.Claims, err error) {
+
 	ba := sha256.Sum256([]byte(password))
 	passwordHash := hex.EncodeToString(ba[:])
 

--- a/auth/ldap-bind/ldap-bind.go
+++ b/auth/ldap-bind/ldap-bind.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/ldap.v2"
 )
 
+// New Authenticator with ldap backend
 func New(server, userTemplate string) api.Authenticator {
 	u, err := url.Parse(server)
 	if err != nil {

--- a/auth/stupid-auth/stupid-auth.go
+++ b/auth/stupid-auth/stupid-auth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mcluseau/autorizo/api"
 )
 
+// New Authenticator with no backend
 func New() api.Authenticator {
 	return stupidAuth{}
 }

--- a/auth/users-file/users-file.go
+++ b/auth/users-file/users-file.go
@@ -21,6 +21,7 @@ var yesValues = map[string]bool{
 	"1":    true,
 }
 
+// New Authenticator with csv file backend
 func New(filePath string) api.Authenticator {
 	return &usersFileAuth{
 		filePath: filePath,

--- a/companion-api/README.md
+++ b/companion-api/README.md
@@ -1,0 +1,56 @@
+## Running
+
+#### With file backend
+
+```sh
+export AUTH_BACKEND=file \
+export AUTH_FILE="autorizo-users.csv" \
+companion-api
+```
+
+#### With etcd backend
+
+```sh
+export AUTH_BACKEND=etcd \
+export ETCD_ENDPOINTS=http://localhost:2379 \
+export ETCD_PREFIX=/users \
+companion-api
+```
+
+### Flags
+
+```
+companion-api --help
+```
+
+### Environment
+
+| Variable         | Description                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| `ETCD_TIMEOUT`   | Simple etcd timeout (default: 5s)                                                      |
+| `ETCD_PREFIX`    | Prefix before the etcd key (default: none)                                             |
+| `ETCD_ENDPOINTS` | Etcd endpoints (format: `ETCD_ENDPOINTS`=http://localhost:2379,http://localhost:4001 ) |
+| `AUTH_FILE`      | Backend file (required if `AUTH_BACKEND`=file)                                         |
+| `AUTH_BACKEND`   | Choose an authentication backend (required)                                            |
+
+### Auth backends
+
+#### stupid
+
+Stupid backend does not need the companion-api.
+
+#### file
+
+Reads or update a content file, defined by the `AUTH_FILE` env, in the format:
+
+```
+<user name>:<password SHA256 (hex)>:email:email_validated:groups
+```
+
+#### LDAP simple bind
+
+Please feel free to use a ldap client instead of the companion-api.
+
+#### etcd lookup
+
+Update or looks up the user in etcd, with a key like `prefix/user-name`. Takes an optionnal `ETCD_TIMEOUT` to change the lookup timeout.

--- a/companion-api/api/api.go
+++ b/companion-api/api/api.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+
+	restful "github.com/emicklei/go-restful"
+	"github.com/mcluseau/autorizo/companion-api/backend"
+)
+
+var (
+	// ErrMissingContent indicates an inexistent user.
+	ErrMissingUser = restful.NewError(http.StatusConflict, "Missing user")
+	// ErrMissingUserId indicates an user without an id.
+	ErrMissingUserId = restful.NewError(http.StatusUnprocessableEntity, "No user id given")
+	// ErrMissingUserPassword indicates an user without a password.
+	ErrMissingUserPassword = restful.NewError(http.StatusUnprocessableEntity, "No user password given.")
+	// ErrUserAlreadyExist indicates an existing user that should not be.
+	ErrUserAlreadyExist = restful.NewError(http.StatusConflict, "User already exist")
+	//ErrPatchFail indicates the json-patch update fails.
+	ErrPatchFail = restful.NewError(http.StatusConflict, "Patch update fails")
+)
+
+// CompanionAPI registering with restful
+type CompanionAPI struct {
+	Client backend.Client
+}
+
+// Register provide a restful.WebService from this API
+func (cApi *CompanionAPI) Register() *restful.WebService {
+	ws := &restful.WebService{}
+	cApi.registerUsers(ws)
+	return ws
+}

--- a/companion-api/api/user.go
+++ b/companion-api/api/user.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	restful "github.com/emicklei/go-restful"
+	"github.com/mcluseau/autorizo/api"
+	"github.com/mcluseau/autorizo/companion-api/backend"
+)
+
+// CreateUserReq is a request to create a new UserData
+type CreateUserReq struct {
+	ID   string           `json:"id"`
+	User backend.UserData `json:"user"`
+}
+
+// Register provide a restful.WebService from this API
+func (cApi *CompanionAPI) registerUsers(ws *restful.WebService) {
+	ws.
+		Route(ws.POST("/users").
+			To(cApi.createUser).
+			Doc("Create a new user.").
+			Consumes("application/json").
+			Reads(CreateUserReq{}))
+
+	ws.
+		Route(ws.PUT("/users/{user-id}").
+			To(cApi.updateUser).
+			Doc("Update an existing user.").
+			Consumes("application/json").
+			Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+			Reads(backend.UserData{}))
+
+	ws.
+		Route(ws.PATCH("/users/{user-id}").
+			To(cApi.patchUser).
+			Doc("Patch an existing user (json-patch format).").
+			Consumes("application/json").
+			Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")))
+
+	ws.
+		Route(ws.DELETE("/users/{user-id}").
+			To(cApi.deleteUser).
+			Doc("Delete an existing user.").
+			Consumes("application/json").
+			Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")))
+
+}
+
+func (cApi *CompanionAPI) createUser(request *restful.Request, response *restful.Response) {
+	defer func() {
+		if err := recover(); err != nil {
+			// unhandled error
+			api.WriteError(err.(error), response)
+		}
+	}()
+
+	userReq := &CreateUserReq{}
+	if err := request.ReadEntity(userReq); err != nil {
+		panic(err)
+	}
+
+	if len(userReq.ID) == 0 {
+		panic(ErrMissingUserId)
+	}
+
+	if len(userReq.User.PasswordHash) == 0 {
+		panic(ErrMissingUserPassword)
+	}
+
+	if err := cApi.Client.CreateUser(userReq.ID, &userReq.User); err != nil {
+		panic(err)
+	}
+
+	response.WriteHeader(http.StatusCreated)
+}
+
+func (cApi *CompanionAPI) updateUser(request *restful.Request, response *restful.Response) {
+	defer func() {
+		if err := recover(); err != nil {
+			// unhandled error
+			api.WriteError(err.(error), response)
+		}
+	}()
+
+	id := request.PathParameter("user-id")
+
+	userData := &backend.UserData{}
+	if err := request.ReadEntity(userData); err != nil {
+		panic(err)
+	}
+
+	err := cApi.Client.UpdateUser(id, func(user *backend.UserData) error {
+		*user = *userData
+		return nil
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	response.WriteHeader(http.StatusOK)
+}
+
+func (cApi *CompanionAPI) patchUser(request *restful.Request, response *restful.Response) {
+	// TODO
+	response.WriteError(http.StatusNotImplemented, errors.New("not implemented"))
+}
+
+func (cApi *CompanionAPI) deleteUser(request *restful.Request, response *restful.Response) {
+	defer func() {
+		if err := recover(); err != nil {
+			// unhandled error
+			api.WriteError(err.(error), response)
+		}
+	}()
+
+	id := request.PathParameter("user-id")
+
+	if err := cApi.Client.DeleteUser(id); err != nil {
+		panic(err)
+	}
+
+	response.WriteHeader(http.StatusOK)
+}

--- a/companion-api/backend/client.go
+++ b/companion-api/backend/client.go
@@ -1,0 +1,18 @@
+package backend
+
+import (
+	"github.com/mcluseau/autorizo/auth"
+)
+
+// UserData is a simple user struct with paswordhash and claims
+type UserData struct {
+	PasswordHash string           `json:"password"`
+	ExtraClaims  auth.ExtraClaims `json:"claims"`
+}
+
+// Client is the interface for all backends clients
+type Client interface {
+	CreateUser(id string, user *UserData) error
+	UpdateUser(id string, update func(user *UserData) error) error
+	DeleteUser(id string) error
+}

--- a/companion-api/backend/etcd/etcd.go
+++ b/companion-api/backend/etcd/etcd.go
@@ -1,0 +1,120 @@
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"path"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/mcluseau/autorizo/companion-api/api"
+	"github.com/mcluseau/autorizo/companion-api/backend"
+)
+
+type etcdClient struct {
+	prefix  string
+	client  *clientv3.Client
+	timeout time.Duration
+}
+
+// New Client to manage users with an etcd backend
+func New(prefix string, endpoints []string) backend.Client {
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints: endpoints,
+	})
+
+	if err != nil {
+		log.Fatal("failed to connect to etcd: ", err)
+	}
+
+	timeout := 5 * time.Second
+	if timeoutEnv := os.Getenv("ETCD_TIMEOUT"); timeoutEnv != "" {
+		timeout, err = time.ParseDuration(timeoutEnv)
+		if err != nil {
+			log.Fatalf("invalid ETCD_TIMEOUT %q: %v", timeoutEnv, timeout)
+		}
+	}
+
+	return &etcdClient{
+		prefix:  prefix,
+		client:  client,
+		timeout: timeout,
+	}
+}
+
+var _ backend.Client = &etcdClient{}
+
+func (e *etcdClient) CreateUser(id string, user *backend.UserData) (err error) {
+	oldUser := &backend.UserData{}
+	oldUser, err = e.getUser(id)
+
+	if oldUser != nil {
+		err = api.ErrUserAlreadyExist
+	} else if err == api.ErrMissingUser {
+		err = e.putUser(id, user)
+	}
+
+	return
+}
+
+func (e *etcdClient) UpdateUser(id string, update func(user *backend.UserData) error) (err error) {
+	user := &backend.UserData{}
+	user, err = e.getUser(id)
+
+	if err == nil && user != nil {
+		err = update(user)
+		if err == nil {
+			err = e.putUser(id, user)
+		}
+	}
+
+	return
+}
+
+func (e *etcdClient) DeleteUser(id string) (err error) {
+	user := &backend.UserData{}
+	user, err = e.getUser(id)
+
+	if err == nil && user != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+		defer cancel()
+
+		_, err = e.client.Delete(ctx, path.Join(e.prefix, id))
+	}
+	return
+}
+
+func (e *etcdClient) getUser(id string) (user *backend.UserData, err error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
+	resp, err := e.client.Get(ctx, path.Join(e.prefix, id))
+	if err != nil {
+		return
+	}
+
+	if len(resp.Kvs) == 0 {
+		err = api.ErrMissingUser
+		return
+	}
+
+	user = &backend.UserData{}
+	err = json.Unmarshal(resp.Kvs[0].Value, user)
+	return
+}
+
+func (e *etcdClient) putUser(id string, user *backend.UserData) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
+	u, err := json.Marshal(*user)
+	if err == nil {
+		_, err = e.client.Put(ctx, path.Join(e.prefix, id), string(u))
+	}
+
+	return
+
+}

--- a/companion-api/backend/users-file/csv.go
+++ b/companion-api/backend/users-file/csv.go
@@ -1,0 +1,102 @@
+package usersfile
+
+import (
+	"encoding/csv"
+	"os"
+	"sync"
+
+	uuid "github.com/nu7hatch/gouuid"
+)
+
+type usersFileWriter struct {
+	mutex       *sync.Mutex
+	writer      *csv.Writer
+	tmpFileName string
+	tmpFile     *os.File
+}
+
+func newUsersFileWriter() (ufw *usersFileWriter, err error) {
+	var f *os.File
+	tmpFileName := tmpFileName()
+
+	f, err = os.Create(tmpFileName)
+	if err != nil {
+		return
+	}
+
+	writer := csv.NewWriter(f)
+	writer.Comma = ':'
+
+	ufw = &usersFileWriter{
+		writer:      writer,
+		mutex:       &sync.Mutex{},
+		tmpFileName: tmpFileName,
+		tmpFile:     f,
+	}
+	return
+}
+
+func (ufw *usersFileWriter) write(record []string) {
+	ufw.mutex.Lock()
+	ufw.writer.Write(record)
+	ufw.mutex.Unlock()
+}
+
+func (ufw *usersFileWriter) flush() {
+	ufw.mutex.Lock()
+	ufw.writer.Flush()
+	ufw.mutex.Unlock()
+}
+
+func (ufw *usersFileWriter) save(filePath string) (err error) {
+	ufw.flush()
+	ufw.tmpFile.Close()
+
+	if err = os.Remove(filePath); err != nil {
+		return
+	}
+
+	err = os.Rename(ufw.tmpFileName, filePath)
+	return
+}
+
+type usersFileReader struct {
+	reader *csv.Reader
+	file   *os.File
+}
+
+func newUsersFileReader(fileName string) (ufr *usersFileReader, err error) {
+	var f *os.File
+
+	f, err = os.Open(fileName)
+	if err != nil {
+		return
+	}
+
+	reader := csv.NewReader(f)
+	reader.Comma = ':'
+
+	ufr = &usersFileReader{
+		reader: reader,
+		file:   f,
+	}
+	return
+}
+
+func (ufr *usersFileReader) read() (record []string, err error) {
+	return ufr.reader.Read()
+}
+
+func (ufr *usersFileReader) close() (err error) {
+	return ufr.file.Close()
+}
+
+func tmpFileName() (fileName string) {
+	uuid, err := uuid.NewV4()
+	if err == nil {
+		fileName = uuid.String()
+	} else {
+		fileName = "autorizo-companion-api-tmp.csv"
+	}
+	return
+}

--- a/companion-api/backend/users-file/users-file.go
+++ b/companion-api/backend/users-file/users-file.go
@@ -1,0 +1,213 @@
+package usersfile
+
+import (
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/mcluseau/autorizo/auth"
+	"github.com/mcluseau/autorizo/companion-api/api"
+	"github.com/mcluseau/autorizo/companion-api/backend"
+)
+
+var toBool = map[string]bool{
+	"true":  true,
+	"yes":   true,
+	"1":     true,
+	"false": false,
+	"no":    false,
+	"0":     false,
+}
+
+type fileClient struct {
+	filePath string
+}
+
+// New Client to manage users with a csv file backend
+func New(filePath string) backend.Client {
+	return &fileClient{
+		filePath: filePath,
+	}
+}
+
+var _ backend.Client = &fileClient{}
+
+func (fc *fileClient) CreateUser(id string, user *backend.UserData) (err error) {
+
+	oldUser := &backend.UserData{}
+	oldUser, err = fc.getUser(id)
+
+	if oldUser != nil {
+		err = api.ErrUserAlreadyExist
+	} else if err == api.ErrMissingUser {
+		err = fc.putUser(id, user.PasswordHash, user.ExtraClaims)
+	}
+
+	return
+}
+
+func (fc *fileClient) UpdateUser(id string, update func(user *backend.UserData) error) (err error) {
+	user := &backend.UserData{}
+	user, err = fc.getUser(id)
+
+	if err == nil && user != nil {
+		err = update(user)
+		if err == nil {
+			err = fc.putUser(id, user.PasswordHash, user.ExtraClaims)
+		}
+	}
+
+	return
+}
+
+func (fc *fileClient) DeleteUser(id string) error {
+
+	var wg sync.WaitGroup
+
+	reader, err := newUsersFileReader(fc.filePath)
+	if err != nil {
+		return err
+	}
+	defer reader.close()
+
+	writer, err := newUsersFileWriter()
+	if err != nil {
+		return err
+	}
+	defer writer.save(fc.filePath)
+
+	recordExist := false
+	for {
+		record, err := reader.read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		if id == record[0] {
+			recordExist = true
+		} else {
+			wg.Add(1)
+			go func(r []string) {
+				writer.write(r)
+				wg.Done()
+			}(record)
+		}
+
+	}
+
+	wg.Wait()
+	if !recordExist {
+		return api.ErrMissingUser
+	}
+
+	return nil
+}
+
+func (fc *fileClient) putUser(id, passwordHash string, claims auth.ExtraClaims) error {
+	var wg sync.WaitGroup
+
+	reader, err := newUsersFileReader(fc.filePath)
+	if err != nil {
+		return err
+	}
+	defer reader.close()
+
+	writer, err := newUsersFileWriter()
+	if err != nil {
+		return err
+	}
+	defer writer.save(fc.filePath)
+
+	recordExist := false
+	for {
+		record, err := reader.read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		if id == record[0] {
+			record[1] = passwordHash
+			record[2] = claims.DisplayName
+			record[3] = claims.Email
+			record[4] = strconv.FormatBool(claims.EmailVerified)
+			record[5] = strings.Join(claims.Groups, ",")
+			recordExist = true
+		}
+
+		wg.Add(1)
+		go func(record []string) {
+			writer.write(record)
+			wg.Done()
+		}(record)
+
+	}
+
+	wg.Wait()
+	if !recordExist {
+		writer.write([]string{
+			id,
+			passwordHash,
+			claims.DisplayName,
+			claims.Email,
+			strconv.FormatBool(claims.EmailVerified),
+			strings.Join(claims.Groups, ","),
+		})
+	}
+
+	return nil
+}
+
+func (fc *fileClient) getUser(id string) (*backend.UserData, error) {
+
+	reader, err := newUsersFileReader(fc.filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.close()
+
+	for {
+		record, err := reader.read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		if len(record) < 2 {
+			// record too short
+			continue
+		}
+
+		if id != record[0] {
+			continue
+		}
+
+		user := &backend.UserData{
+			PasswordHash: record[1],
+		}
+
+		l := len(record)
+		switch {
+		case l >= 6:
+			user.ExtraClaims.Groups = strings.Split(record[5], ",")
+			fallthrough
+		case l == 5:
+			user.ExtraClaims.EmailVerified = toBool[record[4]]
+			fallthrough
+		case l == 4:
+			user.ExtraClaims.Email = record[3]
+			fallthrough
+		case l == 3:
+			user.ExtraClaims.DisplayName = record[2]
+		}
+
+		return user, nil
+	}
+
+	return nil, api.ErrMissingUser
+}

--- a/companion-api/main.go
+++ b/companion-api/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	restful "github.com/emicklei/go-restful"
+	restfulspec "github.com/emicklei/go-restful-openapi"
+
+	companionapi "github.com/mcluseau/autorizo/companion-api/api"
+	"github.com/mcluseau/autorizo/companion-api/backend"
+	"github.com/mcluseau/autorizo/companion-api/backend/etcd"
+	"github.com/mcluseau/autorizo/companion-api/backend/users-file"
+)
+
+var (
+	bind        = flag.String("bind", ":8181", "HTTP bind specification")
+	disableCORS = flag.Bool("no-cors", false, "Disable CORS support")
+)
+
+func main() {
+	flag.Parse()
+
+	cAPI := &companionapi.CompanionAPI{
+		Client: getBackEndClient(),
+	}
+
+	restful.DefaultRequestContentType(restful.MIME_JSON)
+	restful.DefaultResponseContentType(restful.MIME_JSON)
+	restful.DefaultContainer.Router(restful.CurlyRouter{})
+
+	restful.Add(cAPI.Register())
+
+	config := restfulspec.Config{
+		WebServices: restful.RegisteredWebServices(),
+		APIPath:     "/apidocs.json",
+	}
+	restful.DefaultContainer.Add(restfulspec.NewOpenAPIService(config))
+
+	if !*disableCORS {
+		restful.Filter(restful.CrossOriginResourceSharing{
+			CookiesAllowed: true,
+			Container:      restful.DefaultContainer,
+		}.Filter)
+	}
+
+	l, err := net.Listen("tcp", *bind)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Print("listening on ", *bind)
+
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Kill, os.Interrupt, syscall.SIGTERM)
+		<-sig
+
+		log.Print("closing listener")
+		l.Close()
+	}()
+
+	log.Fatal(http.Serve(l, restful.DefaultContainer))
+}
+
+func getBackEndClient() backend.Client {
+
+	switch v := os.Getenv("AUTH_BACKEND"); v {
+	case "stupid":
+		log.Fatal("Stupid backend does not need the companion-api")
+		return nil
+	case "ldap-bind":
+		log.Fatal("Please feel free to use a ldap client instead of the companion-api")
+		return nil
+	case "file":
+		return usersfile.New(requireEnv("AUTH_FILE", "File containings users when using file auth"))
+	case "etcd":
+		return etcd.New(
+			requireEnv("ETCD_PREFIX", "etcd prefix"),
+			strings.Split(requireEnv("ETCD_ENDPOINTS", "etcd endpoints"), ","))
+	default:
+		log.Fatal("Unknown authenticator: ", v)
+		return nil
+	}
+}
+
+func requireEnv(name, description string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		log.Fatal("Env ", name, " is required: ", description)
+	}
+	return v
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.8.0+incompatible
 	github.com/emicklei/go-restful-openapi v1.0.0
+	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/go-openapi/spec v0.18.0 // indirect
 	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20181024230925-c65c006176ff // indirect
@@ -17,6 +18,7 @@ require (
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/prometheus/client_golang v0.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/emicklei/go-restful v2.8.0+incompatible h1:wN8GCRDPGHguIynsnBartv5GUg
 github.com/emicklei/go-restful v2.8.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful-openapi v1.0.0 h1:ZFk3RuCl8ZmG1yUAF/mSbXRi5cuyA/k5+EpHayuuTXM=
 github.com/emicklei/go-restful-openapi v1.0.0/go.mod h1:Q+bHVYfUWv1fvC4FNTsz2AVvFSsXAC7RCiWjF1Sva1A=
+github.com/evanphx/json-patch v4.1.0+incompatible h1:K1MDoo4AZ4wU0GIU/fPmtZg7VpzLjCxu+UwBD1FvwOc=
+github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-openapi/jsonpointer v0.17.0 h1:nH6xp8XdXHx8dqveo0ZuJBluCO2qGrPbDNZ0dwoRHP0=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
@@ -41,6 +43,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -52,9 +55,12 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/onsi/ginkgo v1.5.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -94,6 +100,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6 h1:IcgEB62HYgAhX0Nd/QrVgZlxlcyxbGQHElLUhW2X4Fo=
 golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181221235234-d00ac6d27372/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -118,6 +125,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/ldap.v2 v2.5.1 h1:wiu0okdNfjlBzg6UWvd1Hn8Y+Ux17/u/4nlk4CQr6tU=
 gopkg.in/ldap.v2 v2.5.1/go.mod h1:oI0cpe/D7HRtBQl8aTg+ZmzFUAvu4lsv3eLXMLGFxWk=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -146,6 +146,7 @@ func requireEnv(name, description string) string {
 }
 
 func getAuthenticator() api.Authenticator {
+
 	switch v := os.Getenv("AUTH_BACKEND"); v {
 	case "", "stupid":
 		return stupidauth.New()

--- a/vendor/github.com/evanphx/json-patch/.travis.yml
+++ b/vendor/github.com/evanphx/json-patch/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.8
+  - 1.7
+
+install:
+  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - go get github.com/jessevdk/go-flags
+
+script:
+  - go get
+  - go test -cover ./...
+
+notifications:
+  email: false

--- a/vendor/github.com/evanphx/json-patch/LICENSE
+++ b/vendor/github.com/evanphx/json-patch/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/evanphx/json-patch/README.md
+++ b/vendor/github.com/evanphx/json-patch/README.md
@@ -1,0 +1,292 @@
+# JSON-Patch
+`jsonpatch` is a library which provides functionallity for both applying
+[RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) against documents, as
+well as for calculating & applying [RFC7396 JSON merge patches](https://tools.ietf.org/html/rfc7396).
+
+[![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
+[![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
+[![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
+
+# Get It!
+
+**Latest and greatest**: 
+```bash
+go get -u github.com/evanphx/json-patch
+```
+
+**Stable Versions**:
+* Version 4: `go get -u gopkg.in/evanphx/json-patch.v4`
+
+(previous versions below `v3` are unavailable)
+
+# Use It!
+* [Create and apply a merge patch](#create-and-apply-a-merge-patch)
+* [Create and apply a JSON Patch](#create-and-apply-a-json-patch)
+* [Comparing JSON documents](#comparing-json-documents)
+* [Combine merge patches](#combine-merge-patches)
+
+
+# Configuration
+
+There is a single global configuration variable `jsonpatch.SupportNegativeIndices'. This
+defaults to `true` and enables the non-standard practice of allowing negative indices
+to mean indices starting at the end of an array. This functionality can be disabled
+by setting `jsonpatch.SupportNegativeIndices = false`.
+
+## Create and apply a merge patch
+Given both an original JSON document and a modified JSON document, you can create
+a [Merge Patch](https://tools.ietf.org/html/rfc7396) document. 
+
+It can describe the changes needed to convert from the original to the 
+modified JSON document.
+
+Once you have a merge patch, you can apply it to other JSON documents using the
+`jsonpatch.MergePatch(document, patch)` function.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+func main() {
+	// Let's create a merge patch from these two documents...
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+	target := []byte(`{"name": "Jane", "age": 24}`)
+
+	patch, err := jsonpatch.CreateMergePatch(original, target)
+	if err != nil {
+		panic(err)
+	}
+
+	// Now lets apply the patch against a different JSON document...
+
+	alternative := []byte(`{"name": "Tina", "age": 28, "height": 3.75}`)
+	modifiedAlternative, err := jsonpatch.MergePatch(alternative, patch)
+
+	fmt.Printf("patch document:   %s\n", patch)
+	fmt.Printf("updated alternative doc: %s\n", modifiedAlternative)
+}
+```
+
+When ran, you get the following output:
+
+```bash
+$ go run main.go
+patch document:   {"height":null,"name":"Jane"}
+updated tina doc: {"age":28,"name":"Jane"}
+```
+
+## Create and apply a JSON Patch
+You can create patch objects using `DecodePatch([]byte)`, which can then 
+be applied against JSON documents.
+
+The following is an example of creating a patch from two operations, and
+applying it against a JSON document.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+func main() {
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+	patchJSON := []byte(`[
+		{"op": "replace", "path": "/name", "value": "Jane"},
+		{"op": "remove", "path": "/height"}
+	]`)
+
+	patch, err := jsonpatch.DecodePatch(patchJSON)
+	if err != nil {
+		panic(err)
+	}
+
+	modified, err := patch.Apply(original)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Original document: %s\n", original)
+	fmt.Printf("Modified document: %s\n", modified)
+}
+```
+
+When ran, you get the following output:
+
+```bash
+$ go run main.go
+Original document: {"name": "John", "age": 24, "height": 3.21}
+Modified document: {"age":24,"name":"Jane"}
+```
+
+## Comparing JSON documents
+Due to potential whitespace and ordering differences, one cannot simply compare
+JSON strings or byte-arrays directly. 
+
+As such, you can instead use `jsonpatch.Equal(document1, document2)` to 
+determine if two JSON documents are _structurally_ equal. This ignores
+whitespace differences, and key-value ordering.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+func main() {
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+	similar := []byte(`
+		{
+			"age": 24,
+			"height": 3.21,
+			"name": "John"
+		}
+	`)
+	different := []byte(`{"name": "Jane", "age": 20, "height": 3.37}`)
+
+	if jsonpatch.Equal(original, similar) {
+		fmt.Println(`"original" is structurally equal to "similar"`)
+	}
+
+	if !jsonpatch.Equal(original, different) {
+		fmt.Println(`"original" is _not_ structurally equal to "similar"`)
+	}
+}
+```
+
+When ran, you get the following output:
+```bash
+$ go run main.go
+"original" is structurally equal to "similar"
+"original" is _not_ structurally equal to "similar"
+```
+
+## Combine merge patches
+Given two JSON merge patch documents, it is possible to combine them into a 
+single merge patch which can describe both set of changes.
+
+The resulting merge patch can be used such that applying it results in a
+document structurally similar as merging each merge patch to the document
+in succession. 
+
+```go
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+func main() {
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+
+	nameAndHeight := []byte(`{"height":null,"name":"Jane"}`)
+	ageAndEyes := []byte(`{"age":4.23,"eyes":"blue"}`)
+
+	// Let's combine these merge patch documents...
+	combinedPatch, err := jsonpatch.MergeMergePatches(nameAndHeight, ageAndEyes)
+	if err != nil {
+		panic(err)
+	}
+
+	// Apply each patch individual against the original document
+	withoutCombinedPatch, err := jsonpatch.MergePatch(original, nameAndHeight)
+	if err != nil {
+		panic(err)
+	}
+
+	withoutCombinedPatch, err = jsonpatch.MergePatch(withoutCombinedPatch, ageAndEyes)
+	if err != nil {
+		panic(err)
+	}
+
+	// Apply the combined patch against the original document
+
+	withCombinedPatch, err := jsonpatch.MergePatch(original, combinedPatch)
+	if err != nil {
+		panic(err)
+	}
+
+	// Do both result in the same thing? They should!
+	if jsonpatch.Equal(withCombinedPatch, withoutCombinedPatch) {
+		fmt.Println("Both JSON documents are structurally the same!")
+	}
+
+	fmt.Printf("combined merge patch: %s", combinedPatch)
+}
+```
+
+When ran, you get the following output:
+```bash
+$ go run main.go
+Both JSON documents are structurally the same!
+combined merge patch: {"age":4.23,"eyes":"blue","height":null,"name":"Jane"}
+```
+
+# CLI for comparing JSON documents
+You can install the commandline program `json-patch`.
+
+This program can take multiple JSON patch documents as arguments, 
+and fed a JSON document from `stdin`. It will apply the patch(es) against 
+the document and output the modified doc.
+
+**patch.1.json**
+```json
+[
+    {"op": "replace", "path": "/name", "value": "Jane"},
+    {"op": "remove", "path": "/height"}
+]
+```
+
+**patch.2.json**
+```json
+[
+    {"op": "add", "path": "/address", "value": "123 Main St"},
+    {"op": "replace", "path": "/age", "value": "21"}
+]
+```
+
+**document.json**
+```json
+{
+    "name": "John",
+    "age": 24,
+    "height": 3.21
+}
+```
+
+You can then run:
+
+```bash
+$ go install github.com/evanphx/json-patch/cmd/json-patch
+$ cat document.json | json-patch -p patch.1.json -p patch.2.json
+{"address":"123 Main St","age":"21","name":"Jane"}
+```
+
+# Help It!
+Contributions are welcomed! Leave [an issue](https://github.com/evanphx/json-patch/issues)
+or [create a PR](https://github.com/evanphx/json-patch/compare).
+
+
+Before creating a pull request, we'd ask that you make sure tests are passing
+and that you have added new tests when applicable.
+
+Contributors can run tests using:
+
+```bash
+go test -cover ./...
+```
+
+Builds for pull requests are tested automatically 
+using [TravisCI](https://travis-ci.org/evanphx/json-patch).

--- a/vendor/github.com/evanphx/json-patch/merge.go
+++ b/vendor/github.com/evanphx/json-patch/merge.go
@@ -1,0 +1,383 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+func merge(cur, patch *lazyNode, mergeMerge bool) *lazyNode {
+	curDoc, err := cur.intoDoc()
+
+	if err != nil {
+		pruneNulls(patch)
+		return patch
+	}
+
+	patchDoc, err := patch.intoDoc()
+
+	if err != nil {
+		return patch
+	}
+
+	mergeDocs(curDoc, patchDoc, mergeMerge)
+
+	return cur
+}
+
+func mergeDocs(doc, patch *partialDoc, mergeMerge bool) {
+	for k, v := range *patch {
+		if v == nil {
+			if mergeMerge {
+				(*doc)[k] = nil
+			} else {
+				delete(*doc, k)
+			}
+		} else {
+			cur, ok := (*doc)[k]
+
+			if !ok || cur == nil {
+				pruneNulls(v)
+				(*doc)[k] = v
+			} else {
+				(*doc)[k] = merge(cur, v, mergeMerge)
+			}
+		}
+	}
+}
+
+func pruneNulls(n *lazyNode) {
+	sub, err := n.intoDoc()
+
+	if err == nil {
+		pruneDocNulls(sub)
+	} else {
+		ary, err := n.intoAry()
+
+		if err == nil {
+			pruneAryNulls(ary)
+		}
+	}
+}
+
+func pruneDocNulls(doc *partialDoc) *partialDoc {
+	for k, v := range *doc {
+		if v == nil {
+			delete(*doc, k)
+		} else {
+			pruneNulls(v)
+		}
+	}
+
+	return doc
+}
+
+func pruneAryNulls(ary *partialArray) *partialArray {
+	newAry := []*lazyNode{}
+
+	for _, v := range *ary {
+		if v != nil {
+			pruneNulls(v)
+			newAry = append(newAry, v)
+		}
+	}
+
+	*ary = newAry
+
+	return ary
+}
+
+var errBadJSONDoc = fmt.Errorf("Invalid JSON Document")
+var errBadJSONPatch = fmt.Errorf("Invalid JSON Patch")
+var errBadMergeTypes = fmt.Errorf("Mismatched JSON Documents")
+
+// MergeMergePatches merges two merge patches together, such that
+// applying this resulting merged merge patch to a document yields the same
+// as merging each merge patch to the document in succession.
+func MergeMergePatches(patch1Data, patch2Data []byte) ([]byte, error) {
+	return doMergePatch(patch1Data, patch2Data, true)
+}
+
+// MergePatch merges the patchData into the docData.
+func MergePatch(docData, patchData []byte) ([]byte, error) {
+	return doMergePatch(docData, patchData, false)
+}
+
+func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
+	doc := &partialDoc{}
+
+	docErr := json.Unmarshal(docData, doc)
+
+	patch := &partialDoc{}
+
+	patchErr := json.Unmarshal(patchData, patch)
+
+	if _, ok := docErr.(*json.SyntaxError); ok {
+		return nil, errBadJSONDoc
+	}
+
+	if _, ok := patchErr.(*json.SyntaxError); ok {
+		return nil, errBadJSONPatch
+	}
+
+	if docErr == nil && *doc == nil {
+		return nil, errBadJSONDoc
+	}
+
+	if patchErr == nil && *patch == nil {
+		return nil, errBadJSONPatch
+	}
+
+	if docErr != nil || patchErr != nil {
+		// Not an error, just not a doc, so we turn straight into the patch
+		if patchErr == nil {
+			if mergeMerge {
+				doc = patch
+			} else {
+				doc = pruneDocNulls(patch)
+			}
+		} else {
+			patchAry := &partialArray{}
+			patchErr = json.Unmarshal(patchData, patchAry)
+
+			if patchErr != nil {
+				return nil, errBadJSONPatch
+			}
+
+			pruneAryNulls(patchAry)
+
+			out, patchErr := json.Marshal(patchAry)
+
+			if patchErr != nil {
+				return nil, errBadJSONPatch
+			}
+
+			return out, nil
+		}
+	} else {
+		mergeDocs(doc, patch, mergeMerge)
+	}
+
+	return json.Marshal(doc)
+}
+
+// resemblesJSONArray indicates whether the byte-slice "appears" to be
+// a JSON array or not.
+// False-positives are possible, as this function does not check the internal
+// structure of the array. It only checks that the outer syntax is present and
+// correct.
+func resemblesJSONArray(input []byte) bool {
+	input = bytes.TrimSpace(input)
+
+	hasPrefix := bytes.HasPrefix(input, []byte("["))
+	hasSuffix := bytes.HasSuffix(input, []byte("]"))
+
+	return hasPrefix && hasSuffix
+}
+
+// CreateMergePatch will return a merge patch document capable of converting
+// the original document(s) to the modified document(s).
+// The parameters can be bytes of either two JSON Documents, or two arrays of
+// JSON documents.
+// The merge patch returned follows the specification defined at http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
+func CreateMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalResemblesArray := resemblesJSONArray(originalJSON)
+	modifiedResemblesArray := resemblesJSONArray(modifiedJSON)
+
+	// Do both byte-slices seem like JSON arrays?
+	if originalResemblesArray && modifiedResemblesArray {
+		return createArrayMergePatch(originalJSON, modifiedJSON)
+	}
+
+	// Are both byte-slices are not arrays? Then they are likely JSON objects...
+	if !originalResemblesArray && !modifiedResemblesArray {
+		return createObjectMergePatch(originalJSON, modifiedJSON)
+	}
+
+	// None of the above? Then return an error because of mismatched types.
+	return nil, errBadMergeTypes
+}
+
+// createObjectMergePatch will return a merge-patch document capable of
+// converting the original document to the modified document.
+func createObjectMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDoc := map[string]interface{}{}
+	modifiedDoc := map[string]interface{}{}
+
+	err := json.Unmarshal(originalJSON, &originalDoc)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDoc)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	dest, err := getDiff(originalDoc, modifiedDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(dest)
+}
+
+// createArrayMergePatch will return an array of merge-patch documents capable
+// of converting the original document to the modified document for each
+// pair of JSON documents provided in the arrays.
+// Arrays of mismatched sizes will result in an error.
+func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDocs := []json.RawMessage{}
+	modifiedDocs := []json.RawMessage{}
+
+	err := json.Unmarshal(originalJSON, &originalDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	total := len(originalDocs)
+	if len(modifiedDocs) != total {
+		return nil, errBadJSONDoc
+	}
+
+	result := []json.RawMessage{}
+	for i := 0; i < len(originalDocs); i++ {
+		original := originalDocs[i]
+		modified := modifiedDocs[i]
+
+		patch, err := createObjectMergePatch(original, modified)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, json.RawMessage(patch))
+	}
+
+	return json.Marshal(result)
+}
+
+// Returns true if the array matches (must be json types).
+// As is idiomatic for go, an empty array is not the same as a nil array.
+func matchesArray(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return false
+	}
+	for i := range a {
+		if !matchesValue(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Returns true if the values matches (must be json types)
+// The types of the values must match, otherwise it will always return false
+// If two map[string]interface{} are given, all elements must match.
+func matchesValue(av, bv interface{}) bool {
+	if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+		return false
+	}
+	switch at := av.(type) {
+	case string:
+		bt := bv.(string)
+		if bt == at {
+			return true
+		}
+	case float64:
+		bt := bv.(float64)
+		if bt == at {
+			return true
+		}
+	case bool:
+		bt := bv.(bool)
+		if bt == at {
+			return true
+		}
+	case nil:
+		// Both nil, fine.
+		return true
+	case map[string]interface{}:
+		bt := bv.(map[string]interface{})
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt := bv.([]interface{})
+		return matchesArray(at, bt)
+	}
+	return false
+}
+
+// getDiff returns the (recursive) difference between a and b as a map[string]interface{}.
+func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
+	into := map[string]interface{}{}
+	for key, bv := range b {
+		av, ok := a[key]
+		// value was added
+		if !ok {
+			into[key] = bv
+			continue
+		}
+		// If types have changed, replace completely
+		if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+			into[key] = bv
+			continue
+		}
+		// Types are the same, compare values
+		switch at := av.(type) {
+		case map[string]interface{}:
+			bt := bv.(map[string]interface{})
+			dst := make(map[string]interface{}, len(bt))
+			dst, err := getDiff(at, bt)
+			if err != nil {
+				return nil, err
+			}
+			if len(dst) > 0 {
+				into[key] = dst
+			}
+		case string, float64, bool:
+			if !matchesValue(av, bv) {
+				into[key] = bv
+			}
+		case []interface{}:
+			bt := bv.([]interface{})
+			if !matchesArray(at, bt) {
+				into[key] = bv
+			}
+		case nil:
+			switch bv.(type) {
+			case nil:
+				// Both nil, fine.
+			default:
+				into[key] = bv
+			}
+		default:
+			panic(fmt.Sprintf("Unknown type:%T in key %s", av, key))
+		}
+	}
+	// Now add all deleted values as nil
+	for key := range a {
+		_, found := b[key]
+		if !found {
+			into[key] = nil
+		}
+	}
+	return into, nil
+}

--- a/vendor/github.com/evanphx/json-patch/patch.go
+++ b/vendor/github.com/evanphx/json-patch/patch.go
@@ -1,0 +1,682 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	eRaw = iota
+	eDoc
+	eAry
+)
+
+var SupportNegativeIndices bool = true
+
+type lazyNode struct {
+	raw   *json.RawMessage
+	doc   partialDoc
+	ary   partialArray
+	which int
+}
+
+type operation map[string]*json.RawMessage
+
+// Patch is an ordered collection of operations.
+type Patch []operation
+
+type partialDoc map[string]*lazyNode
+type partialArray []*lazyNode
+
+type container interface {
+	get(key string) (*lazyNode, error)
+	set(key string, val *lazyNode) error
+	add(key string, val *lazyNode) error
+	remove(key string) error
+}
+
+func newLazyNode(raw *json.RawMessage) *lazyNode {
+	return &lazyNode{raw: raw, doc: nil, ary: nil, which: eRaw}
+}
+
+func (n *lazyNode) MarshalJSON() ([]byte, error) {
+	switch n.which {
+	case eRaw:
+		return json.Marshal(n.raw)
+	case eDoc:
+		return json.Marshal(n.doc)
+	case eAry:
+		return json.Marshal(n.ary)
+	default:
+		return nil, fmt.Errorf("Unknown type")
+	}
+}
+
+func (n *lazyNode) UnmarshalJSON(data []byte) error {
+	dest := make(json.RawMessage, len(data))
+	copy(dest, data)
+	n.raw = &dest
+	n.which = eRaw
+	return nil
+}
+
+func (n *lazyNode) intoDoc() (*partialDoc, error) {
+	if n.which == eDoc {
+		return &n.doc, nil
+	}
+
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial document")
+	}
+
+	err := json.Unmarshal(*n.raw, &n.doc)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n.which = eDoc
+	return &n.doc, nil
+}
+
+func (n *lazyNode) intoAry() (*partialArray, error) {
+	if n.which == eAry {
+		return &n.ary, nil
+	}
+
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial array")
+	}
+
+	err := json.Unmarshal(*n.raw, &n.ary)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n.which = eAry
+	return &n.ary, nil
+}
+
+func (n *lazyNode) compact() []byte {
+	buf := &bytes.Buffer{}
+
+	if n.raw == nil {
+		return nil
+	}
+
+	err := json.Compact(buf, *n.raw)
+
+	if err != nil {
+		return *n.raw
+	}
+
+	return buf.Bytes()
+}
+
+func (n *lazyNode) tryDoc() bool {
+	if n.raw == nil {
+		return false
+	}
+
+	err := json.Unmarshal(*n.raw, &n.doc)
+
+	if err != nil {
+		return false
+	}
+
+	n.which = eDoc
+	return true
+}
+
+func (n *lazyNode) tryAry() bool {
+	if n.raw == nil {
+		return false
+	}
+
+	err := json.Unmarshal(*n.raw, &n.ary)
+
+	if err != nil {
+		return false
+	}
+
+	n.which = eAry
+	return true
+}
+
+func (n *lazyNode) equal(o *lazyNode) bool {
+	if n.which == eRaw {
+		if !n.tryDoc() && !n.tryAry() {
+			if o.which != eRaw {
+				return false
+			}
+
+			return bytes.Equal(n.compact(), o.compact())
+		}
+	}
+
+	if n.which == eDoc {
+		if o.which == eRaw {
+			if !o.tryDoc() {
+				return false
+			}
+		}
+
+		if o.which != eDoc {
+			return false
+		}
+
+		for k, v := range n.doc {
+			ov, ok := o.doc[k]
+
+			if !ok {
+				return false
+			}
+
+			if v == nil && ov == nil {
+				continue
+			}
+
+			if !v.equal(ov) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	if o.which != eAry && !o.tryAry() {
+		return false
+	}
+
+	if len(n.ary) != len(o.ary) {
+		return false
+	}
+
+	for idx, val := range n.ary {
+		if !val.equal(o.ary[idx]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (o operation) kind() string {
+	if obj, ok := o["op"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) path() string {
+	if obj, ok := o["path"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) from() string {
+	if obj, ok := o["from"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) value() *lazyNode {
+	if obj, ok := o["value"]; ok {
+		return newLazyNode(obj)
+	}
+
+	return nil
+}
+
+func isArray(buf []byte) bool {
+Loop:
+	for _, c := range buf {
+		switch c {
+		case ' ':
+		case '\n':
+		case '\t':
+			continue
+		case '[':
+			return true
+		default:
+			break Loop
+		}
+	}
+
+	return false
+}
+
+func findObject(pd *container, path string) (container, string) {
+	doc := *pd
+
+	split := strings.Split(path, "/")
+
+	if len(split) < 2 {
+		return nil, ""
+	}
+
+	parts := split[1 : len(split)-1]
+
+	key := split[len(split)-1]
+
+	var err error
+
+	for _, part := range parts {
+
+		next, ok := doc.get(decodePatchKey(part))
+
+		if next == nil || ok != nil {
+			return nil, ""
+		}
+
+		if isArray(*next.raw) {
+			doc, err = next.intoAry()
+
+			if err != nil {
+				return nil, ""
+			}
+		} else {
+			doc, err = next.intoDoc()
+
+			if err != nil {
+				return nil, ""
+			}
+		}
+	}
+
+	return doc, decodePatchKey(key)
+}
+
+func (d *partialDoc) set(key string, val *lazyNode) error {
+	(*d)[key] = val
+	return nil
+}
+
+func (d *partialDoc) add(key string, val *lazyNode) error {
+	(*d)[key] = val
+	return nil
+}
+
+func (d *partialDoc) get(key string) (*lazyNode, error) {
+	return (*d)[key], nil
+}
+
+func (d *partialDoc) remove(key string) error {
+	_, ok := (*d)[key]
+	if !ok {
+		return fmt.Errorf("Unable to remove nonexistent key: %s", key)
+	}
+
+	delete(*d, key)
+	return nil
+}
+
+func (d *partialArray) set(key string, val *lazyNode) error {
+	if key == "-" {
+		*d = append(*d, val)
+		return nil
+	}
+
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	sz := len(*d)
+	if idx+1 > sz {
+		sz = idx + 1
+	}
+
+	ary := make([]*lazyNode, sz)
+
+	cur := *d
+
+	copy(ary, cur)
+
+	if idx >= len(ary) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	ary[idx] = val
+
+	*d = ary
+	return nil
+}
+
+func (d *partialArray) add(key string, val *lazyNode) error {
+	if key == "-" {
+		*d = append(*d, val)
+		return nil
+	}
+
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	ary := make([]*lazyNode, len(*d)+1)
+
+	cur := *d
+
+	if idx >= len(ary) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	if SupportNegativeIndices {
+		if idx < -len(ary) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+
+		if idx < 0 {
+			idx += len(ary)
+		}
+	}
+
+	copy(ary[0:idx], cur[0:idx])
+	ary[idx] = val
+	copy(ary[idx+1:], cur[idx:])
+
+	*d = ary
+	return nil
+}
+
+func (d *partialArray) get(key string) (*lazyNode, error) {
+	idx, err := strconv.Atoi(key)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if idx >= len(*d) {
+		return nil, fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	return (*d)[idx], nil
+}
+
+func (d *partialArray) remove(key string) error {
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	cur := *d
+
+	if idx >= len(cur) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	if SupportNegativeIndices {
+		if idx < -len(cur) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+
+		if idx < 0 {
+			idx += len(cur)
+		}
+	}
+
+	ary := make([]*lazyNode, len(cur)-1)
+
+	copy(ary[0:idx], cur[0:idx])
+	copy(ary[idx:], cur[idx+1:])
+
+	*d = ary
+	return nil
+
+}
+
+func (p Patch) add(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: \"%s\"", path)
+	}
+
+	return con.add(key, op.value())
+}
+
+func (p Patch) remove(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: \"%s\"", path)
+	}
+
+	return con.remove(key)
+}
+
+func (p Patch) replace(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
+	}
+
+	_, ok := con.get(key)
+	if ok != nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing key: %s", path)
+	}
+
+	return con.set(key, op.value())
+}
+
+func (p Patch) move(doc *container, op operation) error {
+	from := op.from()
+
+	con, key := findObject(doc, from)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing from path: %s", from)
+	}
+
+	val, err := con.get(key)
+	if err != nil {
+		return err
+	}
+
+	err = con.remove(key)
+	if err != nil {
+		return err
+	}
+
+	path := op.path()
+
+	con, key = findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing destination path: %s", path)
+	}
+
+	return con.set(key, val)
+}
+
+func (p Patch) test(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch test operation does not apply: is missing path: %s", path)
+	}
+
+	val, err := con.get(key)
+
+	if err != nil {
+		return err
+	}
+
+	if val == nil {
+		if op.value().raw == nil {
+			return nil
+		}
+		return fmt.Errorf("Testing value %s failed", path)
+	} else if op.value() == nil {
+		return fmt.Errorf("Testing value %s failed", path)
+	}
+
+	if val.equal(op.value()) {
+		return nil
+	}
+
+	return fmt.Errorf("Testing value %s failed", path)
+}
+
+func (p Patch) copy(doc *container, op operation) error {
+	from := op.from()
+
+	con, key := findObject(doc, from)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch copy operation does not apply: doc is missing from path: %s", from)
+	}
+
+	val, err := con.get(key)
+	if err != nil {
+		return err
+	}
+
+	path := op.path()
+
+	con, key = findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch copy operation does not apply: doc is missing destination path: %s", path)
+	}
+
+	return con.set(key, val)
+}
+
+// Equal indicates if 2 JSON documents have the same structural equality.
+func Equal(a, b []byte) bool {
+	ra := make(json.RawMessage, len(a))
+	copy(ra, a)
+	la := newLazyNode(&ra)
+
+	rb := make(json.RawMessage, len(b))
+	copy(rb, b)
+	lb := newLazyNode(&rb)
+
+	return la.equal(lb)
+}
+
+// DecodePatch decodes the passed JSON document as an RFC 6902 patch.
+func DecodePatch(buf []byte) (Patch, error) {
+	var p Patch
+
+	err := json.Unmarshal(buf, &p)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Apply mutates a JSON document according to the patch, and returns the new
+// document.
+func (p Patch) Apply(doc []byte) ([]byte, error) {
+	return p.ApplyIndent(doc, "")
+}
+
+// ApplyIndent mutates a JSON document according to the patch, and returns the new
+// document indented.
+func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
+	var pd container
+	if doc[0] == '[' {
+		pd = &partialArray{}
+	} else {
+		pd = &partialDoc{}
+	}
+
+	err := json.Unmarshal(doc, pd)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = nil
+
+	for _, op := range p {
+		switch op.kind() {
+		case "add":
+			err = p.add(&pd, op)
+		case "remove":
+			err = p.remove(&pd, op)
+		case "replace":
+			err = p.replace(&pd, op)
+		case "move":
+			err = p.move(&pd, op)
+		case "test":
+			err = p.test(&pd, op)
+		case "copy":
+			err = p.copy(&pd, op)
+		default:
+			err = fmt.Errorf("Unexpected kind: %s", op.kind())
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if indent != "" {
+		return json.MarshalIndent(pd, "", indent)
+	}
+
+	return json.Marshal(pd)
+}
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+
+var (
+	rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+)
+
+func decodePatchKey(k string) string {
+	return rfc6901Decoder.Replace(k)
+}

--- a/vendor/github.com/nu7hatch/gouuid/.gitignore
+++ b/vendor/github.com/nu7hatch/gouuid/.gitignore
@@ -1,0 +1,11 @@
+_obj
+_test
+*.6
+*.out
+_testmain.go
+\#*
+.\#*
+*.log
+_cgo*
+*.o
+*.a

--- a/vendor/github.com/nu7hatch/gouuid/COPYING
+++ b/vendor/github.com/nu7hatch/gouuid/COPYING
@@ -1,0 +1,19 @@
+Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/nu7hatch/gouuid/README.md
+++ b/vendor/github.com/nu7hatch/gouuid/README.md
@@ -1,0 +1,21 @@
+# Pure Go UUID implementation
+
+This package provides immutable UUID structs and the functions
+NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+and 5 UUIDs as specified in [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt).
+
+## Installation
+
+Use the `go` tool:
+
+	$ go get github.com/nu7hatch/gouuid
+
+## Usage
+
+See [documentation and examples](http://godoc.org/github.com/nu7hatch/gouuid)
+for more information.
+
+## Copyright
+
+Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>. See [COPYING](https://github.com/nu7hatch/gouuid/tree/master/COPYING)
+file for details.

--- a/vendor/github.com/nu7hatch/gouuid/uuid.go
+++ b/vendor/github.com/nu7hatch/gouuid/uuid.go
@@ -1,0 +1,173 @@
+// This package provides immutable UUID structs and the functions
+// NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+// and 5 UUIDs as specified in RFC 4122.
+//
+// Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"regexp"
+)
+
+// The UUID reserved variants. 
+const (
+	ReservedNCS       byte = 0x80
+	ReservedRFC4122   byte = 0x40
+	ReservedMicrosoft byte = 0x20
+	ReservedFuture    byte = 0x00
+)
+
+// The following standard UUIDs are for use with NewV3() or NewV5().
+var (
+	NamespaceDNS, _  = ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceURL, _  = ParseHex("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceOID, _  = ParseHex("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceX500, _ = ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+)
+
+// Pattern used to parse hex string representation of the UUID.
+// FIXME: do something to consider both brackets at one time,
+// current one allows to parse string with only one opening
+// or closing bracket.
+const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
+	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
+
+var re = regexp.MustCompile(hexPattern)
+
+// A UUID representation compliant with specification in
+// RFC 4122 document.
+type UUID [16]byte
+
+// ParseHex creates a UUID object from given hex string
+// representation. Function accepts UUID string in following
+// formats:
+//
+//     uuid.ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//     uuid.ParseHex("{6ba7b814-9dad-11d1-80b4-00c04fd430c8}")
+//     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//
+func ParseHex(s string) (u *UUID, err error) {
+	md := re.FindStringSubmatch(s)
+	if md == nil {
+		err = errors.New("Invalid UUID string")
+		return
+	}
+	hash := md[2] + md[3] + md[4] + md[5] + md[6]
+	b, err := hex.DecodeString(hash)
+	if err != nil {
+		return
+	}
+	u = new(UUID)
+	copy(u[:], b)
+	return
+}
+
+// Parse creates a UUID object from given bytes slice.
+func Parse(b []byte) (u *UUID, err error) {
+	if len(b) != 16 {
+		err = errors.New("Given slice is not valid UUID sequence")
+		return
+	}
+	u = new(UUID)
+	copy(u[:], b)
+	return
+}
+
+// Generate a UUID based on the MD5 hash of a namespace identifier
+// and a name.
+func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
+	if ns == nil {
+		err = errors.New("Invalid namespace UUID")
+		return
+	}
+	u = new(UUID)
+	// Set all bits to MD5 hash generated from namespace and name.
+	u.setBytesFromHash(md5.New(), ns[:], name)
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(3)
+	return
+}
+
+// Generate a random UUID.
+func NewV4() (u *UUID, err error) {
+	u = new(UUID)
+	// Set all bits to randomly (or pseudo-randomly) chosen values.
+	_, err = rand.Read(u[:])
+	if err != nil {
+		return
+	}
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(4)
+	return
+}
+
+// Generate a UUID based on the SHA-1 hash of a namespace identifier
+// and a name.
+func NewV5(ns *UUID, name []byte) (u *UUID, err error) {
+	u = new(UUID)
+	// Set all bits to truncated SHA1 hash generated from namespace
+	// and name.
+	u.setBytesFromHash(sha1.New(), ns[:], name)
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(5)
+	return
+}
+
+// Generate a MD5 hash of a namespace and a name, and copy it to the
+// UUID slice.
+func (u *UUID) setBytesFromHash(hash hash.Hash, ns, name []byte) {
+	hash.Write(ns[:])
+	hash.Write(name)
+	copy(u[:], hash.Sum([]byte{})[:16])
+}
+
+// Set the two most significant bits (bits 6 and 7) of the
+// clock_seq_hi_and_reserved to zero and one, respectively.
+func (u *UUID) setVariant(v byte) {
+	switch v {
+	case ReservedNCS:
+		u[8] = (u[8] | ReservedNCS) & 0xBF
+	case ReservedRFC4122:
+		u[8] = (u[8] | ReservedRFC4122) & 0x7F
+	case ReservedMicrosoft:
+		u[8] = (u[8] | ReservedMicrosoft) & 0x3F
+	}
+}
+
+// Variant returns the UUID Variant, which determines the internal
+// layout of the UUID. This will be one of the constants: RESERVED_NCS,
+// RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
+func (u *UUID) Variant() byte {
+	if u[8]&ReservedNCS == ReservedNCS {
+		return ReservedNCS
+	} else if u[8]&ReservedRFC4122 == ReservedRFC4122 {
+		return ReservedRFC4122
+	} else if u[8]&ReservedMicrosoft == ReservedMicrosoft {
+		return ReservedMicrosoft
+	}
+	return ReservedFuture
+}
+
+// Set the four most significant bits (bits 12 through 15) of the
+// time_hi_and_version field to the 4-bit version number.
+func (u *UUID) setVersion(v byte) {
+	u[6] = (u[6] & 0xF) | (v << 4)
+}
+
+// Version returns a version number of the algorithm used to
+// generate the UUID sequence.
+func (u *UUID) Version() uint {
+	return uint(u[6] >> 4)
+}
+
+// Returns unparsed version of the generated UUID sequence.
+func (u *UUID) String() string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,6 +16,8 @@ github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/emicklei/go-restful-openapi v1.0.0
 github.com/emicklei/go-restful-openapi
+# github.com/evanphx/json-patch v4.1.0+incompatible
+github.com/evanphx/json-patch
 # github.com/go-openapi/jsonpointer v0.17.0
 github.com/go-openapi/jsonpointer
 # github.com/go-openapi/jsonreference v0.17.0
@@ -47,6 +49,8 @@ github.com/mailru/easyjson/buffer
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
+# github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
+github.com/nu7hatch/gouuid
 # golang.org/x/net v0.0.0-20181220203305-927f97764cc3
 golang.org/x/net/context
 golang.org/x/net/trace


### PR DESCRIPTION
Add simple companion-api to:
- get/update claims with jwt.
- update/create user without jwt.

This companion-api works with etcd backend and csv file backend.